### PR TITLE
Huge performance increase when listing artifacts, e.g. Jenkins job or run screens

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
         <changelist>9999-SNAPSHOT</changelist>
         <jenkins.version>2.277.2</jenkins.version>
         <java.level>8</java.level>
-        <windows-azure-storage.version>356.vfa287acbfe71</windows-azure-storage.version>
     </properties>
 
     <licenses>
@@ -56,7 +55,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>windows-azure-storage</artifactId>
-            <version>${windows-azure-storage.version}</version>
+            <version>357.v36c07129d7d3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactManager.java
+++ b/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactManager.java
@@ -402,6 +402,7 @@ public final class AzureArtifactManager extends ArtifactManager implements Stash
         serviceData.setIncludeFilesPattern(stashes + name + Constants.TGZ_FILE_EXTENSION);
         serviceData.setFlattenDirectories(true);
 
+        workspace.mkdirs();
         DownloadService downloadService = new DownloadFromContainerService(serviceData);
         try {
             downloadService.execute();

--- a/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactManager.java
+++ b/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactManager.java
@@ -125,7 +125,7 @@ public final class AzureArtifactManager extends ArtifactManager implements Stash
                 .act(new ContentTypeGuesser(new ArrayList<>(artifacts.keySet()), listener));
 
         try {
-            BlobContainerClient container = Utils.getBlobContainerReference(accountInfo, config.getContainer(), false);
+            BlobContainerClient container = Utils.getBlobContainerReference(accountInfo, config.getContainer(), true);
 
             for (Map.Entry<String, String> entry : contentTypes.entrySet()) {
                 String path = "artifacts/" + entry.getKey();

--- a/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactManager.java
+++ b/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactManager.java
@@ -339,7 +339,7 @@ public final class AzureArtifactManager extends ArtifactManager implements Stash
         return Utils.getBlobContainerReference(
                 accountInfo,
                 this.actualContainerName,
-                true
+                false
         );
     }
 
@@ -373,6 +373,7 @@ public final class AzureArtifactManager extends ArtifactManager implements Stash
             serviceData.setFilePath(stashTempFile.getName());
             serviceData.setUploadType(UploadType.INDIVIDUAL);
 
+            // TODO rewrite to not use azure-storage plugin API like in artifacts
             UploadService uploadService = new UploadToBlobService(serviceData);
             try {
                 uploadService.execute();

--- a/src/main/java/com/microsoft/jenkins/artifactmanager/AzureBlobVirtualFile.java
+++ b/src/main/java/com/microsoft/jenkins/artifactmanager/AzureBlobVirtualFile.java
@@ -9,32 +9,33 @@ import com.azure.core.http.rest.PagedIterable;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.models.BlobItem;
+import com.azure.storage.blob.models.BlobItemProperties;
 import com.azure.storage.blob.models.BlobProperties;
 import com.azure.storage.blob.models.BlobStorageException;
+import com.azure.storage.blob.models.ListBlobsOptions;
 import com.microsoftopentechnologies.windowsazurestorage.beans.StorageAccountInfo;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Run;
 import hudson.remoting.Callable;
 import jenkins.util.VirtualFile;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -43,7 +44,6 @@ public class AzureBlobVirtualFile extends AzureAbstractVirtualFile {
     private static final long serialVersionUID = 9054620703341308471L;
 
     private static final Logger LOGGER = Logger.getLogger(AzureBlobVirtualFile.class.getName());
-    private static final String AZURE_BLOB_URL_PATTERN = "https://%s.blob.core.windows.net/%s/%s";
     private static final int NOT_FOUND = 404;
 
     private final String container;
@@ -64,10 +64,87 @@ public class AzureBlobVirtualFile extends AzureAbstractVirtualFile {
         return this.key;
     }
 
+    /**
+     * Cache of metadata collected during {@link #run}.
+     * Keys are {@link #container}.
+     * Values are a stack of cache frames, one per nested {@link #run} call.
+     */
+    private static final ThreadLocal<Map<String, Deque<CacheFrame>>> CACHE = ThreadLocal.withInitial(HashMap::new);
+
+    private static final class CacheFrame {
+        /** {@link #key} of the root virtual file plus a trailing {@code /}. */
+        private final String root;
+        /**
+         * Information about all known (recursive) child <em>files</em> (not directories).
+         * Keys are {@code /}-separated relative paths.
+         * If the root itself happened to be a file, that information is not cached.
+         */
+        private final Map<String, CachedMetadata> children;
+        CacheFrame(String root, Map<String, CachedMetadata> children) {
+            this.root = root;
+            this.children = children;
+        }
+    }
+
+    /**
+     * Record that a given file exists.
+     */
+    private static final class CachedMetadata {
+        private final long length, lastModified;
+        CachedMetadata(long length, long lastModified) {
+            this.length = length;
+            this.lastModified = lastModified;
+        }
+    }
+
+
     @Override
     public <V> V run(Callable<V, IOException> callable) throws IOException {
-        return super.run(callable);
+        LOGGER.log(Level.FINE, "enter cache {0} / {1}", new Object[] {container, key});
+        Deque<CacheFrame> stack = cacheFrames();
+        Map<String, CachedMetadata> saved = new HashMap<>();
+        try {
+            StorageAccountInfo accountInfo = Utils.getStorageAccount(build.getParent());
+            BlobContainerClient blobContainerReference = Utils.getBlobContainerReference(accountInfo, this.container,
+                    false);
+            ListBlobsOptions listBlobsOptions = new ListBlobsOptions()
+                    .setPrefix(key);
+
+            for (BlobItem sm : blobContainerReference.listBlobs(listBlobsOptions, null)) {
+                BlobItemProperties properties = sm.getProperties();
+                OffsetDateTime lastModified = properties.getLastModified();
+                long lastModifiedMilli = lastModified.toInstant().toEpochMilli();
+                String fileName = sm.getName().replaceFirst(key + "/", "");
+                saved.put(stripTrailingSlash(fileName),
+                        new CachedMetadata(properties.getContentLength(), lastModifiedMilli));
+            }
+        } catch (RuntimeException | URISyntaxException x) {
+            throw new IOException(x);
+        }
+        stack.push(new CacheFrame(stripTrailingSlash(key) + "/", saved));
+        try {
+            LOGGER.log(Level.FINE, "using cache {0} / {1}: {2} file entries",
+                    new Object[] {container, key, saved.size()});
+            return callable.call();
+        } finally {
+            LOGGER.log(Level.FINE, "exit cache {0} / {1}", new Object[] {container, key});
+            stack.pop();
+        }
     }
+
+    private Deque<CacheFrame> cacheFrames() {
+        return CACHE.get().computeIfAbsent(container, c -> new ArrayDeque<>());
+    }
+
+    /**
+     * Finds a cache frame whose {@link CacheFrame#root} is a prefix of the given {@link #key}
+     * or {@code /}-appended variant.
+     *
+     */
+    private @CheckForNull CacheFrame findCacheFrame(String cacheKey) {
+        return cacheFrames().stream().filter(frame -> cacheKey.startsWith(frame.root)).findFirst().orElse(null);
+    }
+
 
     @NonNull
     @Override
@@ -90,22 +167,8 @@ public class AzureBlobVirtualFile extends AzureAbstractVirtualFile {
     public URI toURI() {
         StorageAccountInfo accountInfo = Utils.getStorageAccount(build.getParent());
         try {
-            String encodedKey = StringUtils.replace(this.key, "%", "%25");
-            String formattedUrl = String.format(AZURE_BLOB_URL_PATTERN, accountInfo.getStorageAccName(),
-                    container, encodedKey);
-
-            String decodedURL = URLDecoder.decode(formattedUrl, StandardCharsets.UTF_8.name());
-            URL url = new URL(decodedURL);
-            return new URI(
-                    url.getProtocol(),
-                    url.getUserInfo(),
-                    url.getHost(),
-                    url.getPort(),
-                    url.getPath(),
-                    url.getQuery(),
-                    url.getRef()
-            );
-        } catch (URISyntaxException | MalformedURLException | UnsupportedEncodingException e) {
+            return new URI(Utils.getBlobUrl(accountInfo, this.container, this.key));
+        } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
     }
@@ -131,14 +194,28 @@ public class AzureBlobVirtualFile extends AzureAbstractVirtualFile {
 
     @Override
     public boolean isDirectory() throws IOException {
-        String keyWithSlash = stripTrailingSlash(this.key) + Constants.FORWARD_SLASH;
-        LOGGER.log(Level.FINE, "checking directory status {0} / {1}", new Object[]{container, keyWithSlash});
+        String keyWithNoSlash = stripTrailingSlash(this.key);
+
+        if (keyWithNoSlash.endsWith("/*view*")) {
+            return false;
+        }
+
+        String keyS = keyWithNoSlash + "/";
+        CacheFrame frame = findCacheFrame(keyS);
+        if (frame != null) {
+            LOGGER.log(Level.FINER, "cache hit on directory status of {0} / {1}", new Object[] {container, this.key});
+            String relSlash = key.substring(frame.root.length()); // "" or "sub/dir/"
+            boolean existsInCache = frame.children.keySet().stream().anyMatch(f -> f.equals(relSlash));
+            return !existsInCache;
+        }
+
+        LOGGER.log(Level.FINE, "checking directory status {0} / {1}", new Object[]{container, keyWithNoSlash});
 
         StorageAccountInfo accountInfo = Utils.getStorageAccount(build.getParent());
         try {
             BlobContainerClient blobContainerReference = Utils.getBlobContainerReference(accountInfo, this.container,
                     false);
-            Iterator<BlobItem> iterator = blobContainerReference.listBlobsByHierarchy(keyWithSlash).iterator();
+            Iterator<BlobItem> iterator = blobContainerReference.listBlobsByHierarchy(keyS).iterator();
             return iterator.hasNext();
         } catch (URISyntaxException e) {
             throw new IOException(e);
@@ -147,6 +224,20 @@ public class AzureBlobVirtualFile extends AzureAbstractVirtualFile {
 
     @Override
     public boolean isFile() throws IOException {
+        String keyS = key + "/";
+
+        if (keyS.endsWith("/*view*/")) {
+            return false;
+        }
+
+        CacheFrame frame = findCacheFrame(keyS);
+        if (frame != null) {
+            String rel = key.substring(frame.root.length());
+            CachedMetadata metadata = frame.children.get(rel);
+            LOGGER.log(Level.FINER, "cache hit on file status of {0} / {1}", new Object[] {container, key});
+            return metadata != null;
+        }
+
         StorageAccountInfo accountInfo = Utils.getStorageAccount(build.getParent());
         try {
             BlobContainerClient blobContainerReference = Utils.getBlobContainerReference(accountInfo, this.container,
@@ -166,10 +257,22 @@ public class AzureBlobVirtualFile extends AzureAbstractVirtualFile {
     @NonNull
     @Override
     public VirtualFile[] list() throws IOException {
-        if (StringUtils.isBlank(this.container)) {
-            // compatible with version before 0.1.2
-            return new VirtualFile[0];
+        String keyS = key + "/";
+        CacheFrame frame = findCacheFrame(keyS);
+        if (frame != null) {
+            LOGGER.log(Level.FINER, "cache hit on listing of {0} / {1}", new Object[] {container, key});
+            String relSlash = keyS.substring(frame.root.length()); // "" or "sub/dir/"
+            VirtualFile[] virtualFiles = frame.children.keySet().stream() // filenames relative to frame root
+                    .filter(f -> f.startsWith(relSlash)) // those inside this dir
+                    // just the file simple name, or direct subdir name
+                    .map(f -> f.substring(relSlash.length()).replaceFirst("/.+", ""))
+                    .distinct() // ignore duplicates if have multiple files under one direct subdir
+                    // direct children
+                    .map(simple -> new AzureBlobVirtualFile(this.container, keyS + simple, this.build))
+                    .toArray(VirtualFile[]::new);
+            return virtualFiles;
         }
+
         VirtualFile[] list;
         String keys = stripTrailingSlash(this.key) + Constants.FORWARD_SLASH;
 
@@ -202,6 +305,14 @@ public class AzureBlobVirtualFile extends AzureAbstractVirtualFile {
 
     @Override
     public long length() throws IOException {
+        CacheFrame frame = findCacheFrame(key + "/");
+        if (frame != null) {
+            String rel = key.substring(frame.root.length());
+            CachedMetadata metadata = frame.children.get(rel);
+            LOGGER.log(Level.FINER, "cache hit on length of {0} / {1}", new Object[] {container, key});
+            return metadata != null ? metadata.length : 0;
+        }
+
         StorageAccountInfo accountInfo = Utils.getStorageAccount(build.getParent());
         try {
             BlobContainerClient blobContainerReference = Utils.getBlobContainerReference(accountInfo, this.container,
@@ -223,6 +334,14 @@ public class AzureBlobVirtualFile extends AzureAbstractVirtualFile {
 
     @Override
     public long lastModified() throws IOException {
+        CacheFrame frame = findCacheFrame(key + "/");
+        if (frame != null) {
+            String rel = key.substring(frame.root.length());
+            CachedMetadata metadata = frame.children.get(rel);
+            LOGGER.log(Level.FINER, "cache hit on lastModified of {0} / {1}", new Object[] {container, key});
+            return metadata != null ? metadata.lastModified : 0;
+        }
+
         if (isDirectory()) {
             return 0;
         }

--- a/src/test/java/com/microsoft/jenkins/artifactmanager/AzureArtifactConfigTest.java
+++ b/src/test/java/com/microsoft/jenkins/artifactmanager/AzureArtifactConfigTest.java
@@ -20,7 +20,7 @@ public class AzureArtifactConfigTest {
 
 
     @Test
-    public void testContainerName() throws Exception {
+    public void testContainerName() {
 
         // checking for container name length of 3 characters
         assertEquals(FormValidation.ok(), descriptor.doCheckContainer("abc"));

--- a/src/test/java/com/microsoft/jenkins/artifactmanager/AzureArtifactManagerTest.java
+++ b/src/test/java/com/microsoft/jenkins/artifactmanager/AzureArtifactManagerTest.java
@@ -1,8 +1,0 @@
-package com.microsoft.jenkins.artifactmanager;
-
-public class AzureArtifactManagerTest {
-    AzureArtifactManagerFactory getArtifactManagerFactory() {
-//        return new AzureArtifactManagerFactory();
-        return null;
-    }
-}

--- a/src/test/java/com/microsoft/jenkins/artifactmanager/IntegrationTests/ArtifactManagerIT.java
+++ b/src/test/java/com/microsoft/jenkins/artifactmanager/IntegrationTests/ArtifactManagerIT.java
@@ -166,9 +166,7 @@ public class ArtifactManagerIT extends IntegrationTest {
 
     @Test
     public void artifactStash() throws Throwable {
-        // TODO haven't managed to get weird characters test fully working, disabled for now
-        // TODO might work now?
-        ArtifactManagerTest.artifactStashAndDelete(j, getArtifactManagerFactory(), false, null);
+        ArtifactManagerTest.artifactStashAndDelete(j, getArtifactManagerFactory(), true, null);
     }
 
     private ArtifactManagerFactory getArtifactManagerFactory() {

--- a/src/test/java/com/microsoft/jenkins/artifactmanager/IntegrationTests/ArtifactManagerIT.java
+++ b/src/test/java/com/microsoft/jenkins/artifactmanager/IntegrationTests/ArtifactManagerIT.java
@@ -167,6 +167,7 @@ public class ArtifactManagerIT extends IntegrationTest {
     @Test
     public void artifactStash() throws Throwable {
         // TODO haven't managed to get weird characters test fully working, disabled for now
+        // TODO might work now?
         ArtifactManagerTest.artifactStashAndDelete(j, getArtifactManagerFactory(), false, null);
     }
 


### PR DESCRIPTION
* Loads all properties for all files in the `Run` that is currently being looked at into an in-memory cache, this prevents multiple calls being needed for checking things like file size and last modified
* Switches to listBlob with prefix instead of list by hierarchy, the rest api flattens the response without us having to deal with a hierarchy
* Remove unnecessary calls to `exists`

APIs calls were monitored by using the [Azurite](https://github.com/Azure/Azurite) blob storage emulator.

TODO:
- [x] Integration tests are currently failing
- [x] Verify a new container will be created at some point, I may have turned all that off
- [x] See if special names test passes now
- [x] Create a separate issue for optimising stashes, it's calling the storage plugin API which is not optimised - https://github.com/jenkinsci/azure-artifact-manager-plugin/issues/22
- [x] Include before / after API call diff on this PR


## Archive Artifacts

1 artifact was used in the test

Not much difference here, just saved one call to check if a container exists

<details>

<summary>Before</summary>

```
172.17.0.1 - - [19/May/2021:07:07:17 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:07:39 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:07:39 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/stashes/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:07:40 +0000] "PUT /devstoreaccount1/jenkins/nullpipeline-test-env%2F11%2Fartifacts%2Fnested-dir%2Fone%2Ftwo%2Fblah.html?sv=2020-04-08&se=2021-05-19T08%3A07%3A17Z&sp=w&sig=Cgkd6AbpBG%2BcJqgaMET75EezbaE9chnvglUhjqzccUY%3D&sr=b HTTP/1.1" 201
```

</details>


<details>

<summary>After</summary>

```
172.17.0.1 - - [19/May/2021:07:03:27 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:03:27 +0000] "PUT /devstoreaccount1/jenkins/pipeline%2F80%2Fartifacts%2Fnested-dir%2Fone%2Ftwo%2Fblah.html?sv=2020-06-12&se=2021-05-19T08%3A03%3A27Z&sp=w&sig=An%2FuKMVGLjpf0vSXaAi21rmr%2B8H5GmPv%2FsuTVwAXuzE%3D&sr=b HTTP/1.1" 201 -
172.17.0.1 - - [19/May/2021:07:03:28 +0000] "GET /devstoreaccount1/jenkins?restype=container&comp=list&prefix=pipeline/80/stashes/&delimiter=/ HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:03:28 +0000] "GET /devstoreaccount1/jenkins?restype=container&comp=list&prefix=pipeline/80/artifacts HTTP/1.1" 200 -
```

</details>

## Listing artifacts

1 artifact was used in the test

Huge difference here, 68 API calls down to 1. There was a couple of fixes here:
1. Previously an API call was done to list each folder and the method was called recursively, used a more appropriate SDK call which flattens the response on the server side.
2. Implemented the `run()` method in `VirtualFile` which allows running a set of operations at once, basically when the artifacts view is opened it calls a number of methods, `isDirectory`, `isFile`, `length`, `lastModified`, previously it was making an API call for each of those methods, now we have an in memory cache that is used while the run is being looked at and then evicted. This was also harmed by 1) as well.

<details>

<summary>Before</summary>

```
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "HEAD /devstoreaccount1/jenkins/nullpipeline-test-env%2F11%2Fartifacts%2Fnested-dir HTTP/1.1" 404 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/nested-dir/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/nested-dir/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/nested-dir/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "HEAD /devstoreaccount1/jenkins/nullpipeline-test-env%2F11%2Fartifacts%2Fnested-dir%2Fone HTTP/1.1" 404 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/nested-dir/one/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/nested-dir/one/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/nested-dir/one/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "HEAD /devstoreaccount1/jenkins/nullpipeline-test-env%2F11%2Fartifacts%2Fnested-dir%2Fone%2Ftwo HTTP/1.1" 404 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/nested-dir/one/two/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/nested-dir/one/two/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/nested-dir/one/two/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "HEAD /devstoreaccount1/jenkins/nullpipeline-test-env%2F11%2Fartifacts%2Fnested-dir%2Fone%2Ftwo%2Fblah.html HTTP/1.1" 200 53
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "HEAD /devstoreaccount1/jenkins/nullpipeline-test-env%2F11%2Fartifacts%2Fnested-dir%2Fone%2Ftwo%2Fblah.html HTTP/1.1" 200 53
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/nested-dir/one/two/blah.html/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:00 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/nested-dir/one/two/blah.html/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "HEAD /devstoreaccount1/jenkins/nullpipeline-test-env%2F11%2Fartifacts%2Fnested-dir HTTP/1.1" 404 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/nested-dir/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/nested-dir/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/nested-dir/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "HEAD /devstoreaccount1/jenkins/nullpipeline-test-env%2F11%2Fartifacts%2Fnested-dir%2Fone HTTP/1.1" 404 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/nested-dir/one/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/nested-dir/one/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/nested-dir/one/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "HEAD /devstoreaccount1/jenkins/nullpipeline-test-env%2F11%2Fartifacts%2Fnested-dir%2Fone%2Ftwo HTTP/1.1" 404 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/nested-dir/one/two/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/nested-dir/one/two/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/nested-dir/one/two/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "HEAD /devstoreaccount1/jenkins/nullpipeline-test-env%2F11%2Fartifacts%2Fnested-dir%2Fone%2Ftwo%2Fblah.html HTTP/1.1" 200 53
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "HEAD /devstoreaccount1/jenkins/nullpipeline-test-env%2F11%2Fartifacts%2Fnested-dir%2Fone%2Ftwo%2Fblah.html HTTP/1.1" 200 53
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/nested-dir/one/two/blah.html/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?restype=container HTTP/1.1" 200 -
172.17.0.1 - - [19/May/2021:07:09:01 +0000] "GET /devstoreaccount1/jenkins?prefix=nullpipeline-test-env/11/artifacts/nested-dir/one/two/blah.html/&delimiter=/&restype=container&comp=list HTTP/1.1" 200 -
```

</details>

<details>

<summary>After</summary>

```
172.17.0.1 - - [19/May/2021:07:10:26 +0000] "GET /devstoreaccount1/jenkins?restype=container&comp=list&prefix=pipeline/80/artifacts HTTP/1.1" 200 -
```

</details>

