### PR TITLE
Handle / in branch name

### DIFF
--- a/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactManager.java
+++ b/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactManager.java
@@ -106,7 +106,7 @@ public final class AzureArtifactManager extends ArtifactManager implements Stash
     @Override
     public void onLoad(Run<?, ?> aBuild) {
         this.defaultKey = String.format(Constants.BUILD_PREFIX_FORMAT, aBuild.getParent().getFullName(),
-                aBuild.getNumber());
+                aBuild.getNumber()).replace("%2F", "/");
     }
 
     @Override

--- a/src/main/java/com/microsoft/jenkins/artifactmanager/AzureBlobVirtualFile.java
+++ b/src/main/java/com/microsoft/jenkins/artifactmanager/AzureBlobVirtualFile.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -106,6 +107,7 @@ public class AzureBlobVirtualFile extends AzureAbstractVirtualFile {
         Map<String, CachedMetadata> saved = new HashMap<>();
         try {
             StorageAccountInfo accountInfo = Utils.getStorageAccount(build.getParent());
+            Objects.requireNonNull(this.container, "Container must not be null");
             BlobContainerClient blobContainerReference = Utils.getBlobContainerReference(accountInfo, this.container,
                     false);
             ListBlobsOptions listBlobsOptions = new ListBlobsOptions()


### PR DESCRIPTION
From what I can tell we were sending it with %2F in the folder name but Azure just interprets that as you want a slash.

So we need to roundtrip in both directions with a /, this seems to be the easiest fix

Fixes https://github.com/jenkinsci/azure-artifact-manager-plugin/issues/24