### PR TITLE
Add disable external url option

### DIFF
--- a/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactConfig.java
+++ b/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactConfig.java
@@ -62,7 +62,7 @@ public class AzureArtifactConfig extends AbstractDescribableImpl<AzureArtifactCo
         this.prefix = prefix;
     }
 
-    public Boolean getDisableExternalUrl() {
+    public boolean getDisableExternalUrl() {
         return disableExternalUrl;
     }
 

--- a/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactConfig.java
+++ b/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactConfig.java
@@ -34,7 +34,7 @@ public class AzureArtifactConfig extends AbstractDescribableImpl<AzureArtifactCo
     private String storageCredentialId;
     private String container;
     private String prefix;
-    private Boolean disableExternalUrl;
+    private boolean disableExternalUrl;
 
     public AzureArtifactConfig() {
     }

--- a/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactConfig.java
+++ b/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactConfig.java
@@ -67,7 +67,7 @@ public class AzureArtifactConfig extends AbstractDescribableImpl<AzureArtifactCo
     }
 
     @DataBoundSetter
-    public void setDisableExternalUrl(Boolean disableExternalUrl) {
+    public void setDisableExternalUrl(boolean disableExternalUrl) {
         this.disableExternalUrl = disableExternalUrl;
     }
 

--- a/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactConfig.java
+++ b/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactConfig.java
@@ -34,6 +34,7 @@ public class AzureArtifactConfig extends AbstractDescribableImpl<AzureArtifactCo
     private String storageCredentialId;
     private String container;
     private String prefix;
+    private Boolean disableExternalUrl;
 
     public AzureArtifactConfig() {
     }
@@ -59,6 +60,15 @@ public class AzureArtifactConfig extends AbstractDescribableImpl<AzureArtifactCo
     @DataBoundSetter
     public void setPrefix(String prefix) {
         this.prefix = prefix;
+    }
+
+    public Boolean getDisableExternalUrl() {
+        return disableExternalUrl;
+    }
+
+    @DataBoundSetter
+    public void setDisableExternalUrl(Boolean disableExternalUrl) {
+        this.disableExternalUrl = disableExternalUrl;
     }
 
     public String getStorageCredentialId() {

--- a/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactManager.java
+++ b/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactManager.java
@@ -397,7 +397,8 @@ public final class AzureArtifactManager extends ArtifactManager implements Stash
 
     @Override
     public VirtualFile root() {
-        return new AzureBlobVirtualFile(this.actualContainerName, getVirtualPath("artifacts"), build);
+        return new AzureBlobVirtualFile(this.actualContainerName, getVirtualPath("artifacts"),
+            this.config.getDisableExternalUrl(), build);
     }
 
     @Override

--- a/src/main/java/com/microsoft/jenkins/artifactmanager/AzureBlobVirtualFile.java
+++ b/src/main/java/com/microsoft/jenkins/artifactmanager/AzureBlobVirtualFile.java
@@ -188,7 +188,7 @@ public class AzureBlobVirtualFile extends AzureAbstractVirtualFile {
     @CheckForNull
     @Override
     public URL toExternalURL() throws IOException {
-        if (this.disableExternalUrl == null || !this.disableExternalUrl) {
+        if (!this.disableExternalUrl) {
             StorageAccountInfo accountInfo = Utils.getStorageAccount(build.getParent());
             String sas;
             try {

--- a/src/main/java/com/microsoft/jenkins/artifactmanager/AzureBlobVirtualFile.java
+++ b/src/main/java/com/microsoft/jenkins/artifactmanager/AzureBlobVirtualFile.java
@@ -53,7 +53,7 @@ public class AzureBlobVirtualFile extends AzureAbstractVirtualFile {
     private Boolean disableExternalUrl;
     private final transient Run<?, ?> build;
 
-    public AzureBlobVirtualFile(String container, String key, Boolean disableExternalUrl, Run<?, ?> build) {
+    public AzureBlobVirtualFile(String container, String key, boolean disableExternalUrl, Run<?, ?> build) {
         this.container = container;
         this.key = key;
         this.build = build;

--- a/src/main/resources/com/microsoft/jenkins/artifactmanager/AzureArtifactConfig/config.jelly
+++ b/src/main/resources/com/microsoft/jenkins/artifactmanager/AzureArtifactConfig/config.jelly
@@ -14,5 +14,8 @@
         <f:entry title="${%Prefix_title}" field="prefix">
             <f:textbox/>
         </f:entry>
+        <f:entry title="${%DisableExternalUrl_title}" field="disableExternalUrl">
+            <f:checkbox/>
+        </f:entry>
     </f:section>
 </j:jelly>

--- a/src/main/resources/com/microsoft/jenkins/artifactmanager/AzureArtifactConfig/config.properties
+++ b/src/main/resources/com/microsoft/jenkins/artifactmanager/AzureArtifactConfig/config.properties
@@ -3,3 +3,4 @@ Credentials_setting_title=Azure Storage Credentials Settings
 Access_setting_title=Azure Storage Access Settings
 Container_name_title=Azure Container Name
 Prefix_title=Base Prefix (Optional)
+DisableExternalUrl_title=Disable External URL (Optional)

--- a/src/main/resources/com/microsoft/jenkins/artifactmanager/AzureArtifactConfig/help-disableExternalUrl.html
+++ b/src/main/resources/com/microsoft/jenkins/artifactmanager/AzureArtifactConfig/help-disableExternalUrl.html
@@ -1,0 +1,3 @@
+<p>
+    if checked, Azure Storage will not generate a permalink via a Blob SAS URL for the file.
+</p>

--- a/src/main/resources/com/microsoft/jenkins/artifactmanager/AzureArtifactConfig/help-disableExternalUrl.html
+++ b/src/main/resources/com/microsoft/jenkins/artifactmanager/AzureArtifactConfig/help-disableExternalUrl.html
@@ -1,3 +1,3 @@
 <p>
-    if checked, Azure Storage will not generate a permalink via a Blob SAS URL for the file.
+    If checked, artifacts will be accessed under a Jenkins URL and not an Azure Storage URL.
 </p>

--- a/src/test/java/com/microsoft/jenkins/artifactmanager/IntegrationTests/AzureBlobVirtualFileIT.java
+++ b/src/test/java/com/microsoft/jenkins/artifactmanager/IntegrationTests/AzureBlobVirtualFileIT.java
@@ -79,11 +79,11 @@ public class AzureBlobVirtualFileIT extends IntegrationTest {
         uploadFile(tempFile, TEMP_FILE_RELATIVE_PATH);
         uploadFile(subTempFile, SUB_TEMP_FILE_RELATIVE_PATH);
 
-        root = new AzureBlobVirtualFile(containerName, ROOT_FOLDER_NAME, run);
-        subDir = new AzureBlobVirtualFile(containerName, SUB_FOLDER_RELATIVE_PATH, run);
-        temp = new AzureBlobVirtualFile(containerName, TEMP_FILE_RELATIVE_PATH, run);
-        subTemp = new AzureBlobVirtualFile(containerName, SUB_TEMP_FILE_RELATIVE_PATH, run);
-        missing = new AzureBlobVirtualFile(containerName, "missing", run);
+        root = new AzureBlobVirtualFile(containerName, ROOT_FOLDER_NAME, false, run);
+        subDir = new AzureBlobVirtualFile(containerName, SUB_FOLDER_RELATIVE_PATH, false, run);
+        temp = new AzureBlobVirtualFile(containerName, TEMP_FILE_RELATIVE_PATH, false, run);
+        subTemp = new AzureBlobVirtualFile(containerName, SUB_TEMP_FILE_RELATIVE_PATH, false, run);
+        missing = new AzureBlobVirtualFile(containerName, "missing", false, run);
     }
 
     private void uploadFile(File file, String cloudFileName) {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fixes #96
Add disable external url option. 
One option can disable Jenkins from generating SAS URLs when users want to view artifact files in a closed network.
### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->