### PR TITLE
Wait for all uploads to complete

### DIFF
--- a/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactManager.java
+++ b/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactManager.java
@@ -62,6 +62,7 @@ import java.io.Serializable;
 import java.net.URISyntaxException;
 import java.net.URLConnection;
 import java.nio.file.Files;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -74,9 +75,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-// For Duration (if using Azure SDK methods)
-import java.time.Duration;
 
 import static com.microsoft.jenkins.artifactmanager.Utils.generateExpiryDate;
 

--- a/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactManager.java
+++ b/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactManager.java
@@ -62,16 +62,21 @@ import java.io.Serializable;
 import java.net.URISyntaxException;
 import java.net.URLConnection;
 import java.nio.file.Files;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+// For Duration (if using Azure SDK methods)
+import java.time.Duration;
 
 import static com.microsoft.jenkins.artifactmanager.Utils.generateExpiryDate;
 
@@ -285,6 +290,7 @@ public final class AzureArtifactManager extends ArtifactManager implements Stash
             // likely less efficient although not really tested for scale yet.
             // https://github.com/jenkinsci/azure-artifact-manager-plugin/issues/26
             if (uploadObjects.size() < MAX_QUEUE_SIZE_IN_NETTY) {
+                CountDownLatch latch = new CountDownLatch(uploadObjects.size());
                 for (UploadObject uploadObject : uploadObjects) {
                     BlobUrlParts blobUrlParts = BlobUrlParts.parse(uploadObject.getUrl());
 
@@ -296,18 +302,39 @@ public final class AzureArtifactManager extends ArtifactManager implements Stash
                     blobClient.uploadFromFileWithResponse(options)
                             .doOnError(throwable -> listener.error("[AzureStorage] Failed to upload file %s, error: %s",
                                     file, throwable.getMessage()))
+                            .doOnSuccess(response -> latch.countDown())
                             .subscribe();
                 }
+
+                try {
+                    if (!latch.await(Math.max(TIMEOUT, TIMEOUT * uploadObjects.size()), TimeUnit.SECONDS)) {
+                        listener.error("[AzureStorage] Timeout occurred while uploading files");
+                    }
+                } catch (InterruptedException e) {
+                    listener.error("[AzureStorage] Upload process was interrupted", e);
+                    Thread.currentThread().interrupt();
+                }
             } else {
-                uploadObjects.parallelStream()
+                try {
+                    uploadObjects.parallelStream()
                         .forEach(uploadObject -> {
                             BlobUrlParts blobUrlParts = BlobUrlParts.parse(uploadObject.getUrl());
                             BlobClient blobClient = getSynchronousBlobClient(blobUrlParts);
                             String file = new File(f, uploadObject.getName()).getAbsolutePath();
                             BlobUploadFromFileOptions options = new BlobUploadFromFileOptions(file)
                                     .setHeaders(getBlobHttpHeaders(uploadObject));
-                            blobClient.uploadFromFileWithResponse(options, Duration.ofSeconds(TIMEOUT), null);
+
+                            try {
+                                blobClient.uploadFromFileWithResponse(options, Duration.ofSeconds(TIMEOUT), null);
+                            } catch (Exception e) {
+                                listener.error("[AzureStorage] Failed to upload file %s, error: %s",
+                                    file, e.getMessage());
+                                throw new CompletionException(e);
+                            }
                         });
+                } catch (CompletionException e) {
+                    listener.error("[AzureStorage] One or more file uploads failed");
+                }
             }
             return null;
         }


### PR DESCRIPTION
This change introduces a fix for #48 by using a CountDownLatch to wait until all files are uploaded.

Fixes #48

### Testing done

Ran the existing integration tests.
Tested with: https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/plugins/azure-artifact-manager/181.v233fd271dd66/azure-artifact-manager-181.v233fd271dd66.hpi

![image](https://github.com/user-attachments/assets/400f2d58-8396-4669-8f1c-0c2a5a5aae50)


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

