### PR TITLE
fix: Support use with Pipeline Maven Integration Plugin

### DIFF
--- a/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactManager.java
+++ b/src/main/java/com/microsoft/jenkins/artifactmanager/AzureArtifactManager.java
@@ -138,7 +138,7 @@ public final class AzureArtifactManager extends ArtifactManager implements Stash
         List<UploadObject> objects = new ArrayList<>();
 
         Map<String, String> contentTypes = workspace
-                .act(new ContentTypeGuesser(new ArrayList<>(artifacts.keySet()), listener));
+                .act(new ContentTypeGuesser(new ArrayList<>(artifacts.values()), listener));
 
         try {
             BlobContainerClient container = Utils.getBlobContainerReference(
@@ -147,7 +147,7 @@ public final class AzureArtifactManager extends ArtifactManager implements Stash
                     true
             );
 
-            for (Map.Entry<String, String> entry : contentTypes.entrySet()) {
+            for (Map.Entry<String, String> entry : artifacts.entrySet()) {
                 String path = "artifacts/" + entry.getKey();
                 String blobPath = getBlobPath(path);
 
@@ -155,7 +155,9 @@ public final class AzureArtifactManager extends ArtifactManager implements Stash
                 String sas = generateSas(blobClient);
                 String blobUrl = blobClient.getBlobUrl() + "?" + sas;
 
-                UploadObject uploadObject = new UploadObject(entry.getKey(), blobUrl, entry.getValue());
+                UploadObject uploadObject = new UploadObject(
+                        entry.getValue(), blobUrl, contentTypes.get(entry.getValue()
+                ));
                 objects.add(uploadObject);
             }
 


### PR DESCRIPTION
Instead of iterating over artifacts the current code iterates over detected content types. By doing this the Azure Artifact Manager plugin would only support uploading artifacts under the same destination path as it's source path. The [Pipeline Maven Integration Plugin](https://plugins.jenkins.io/pipeline-maven/) uses a custom destination path and is therefor incompatible with the current version of this plugin.

### Testing done

Tested using https://github.com/Azure/Azurite running in a Docker container.

Pipeline Maven Integration Plugin test:
```
pipeline {
    agent any

    tools {
        // Install the Maven version configured as "M3" and add it to the path.
        maven "M3"
    }

    stages {
        stage('Build') {
            steps {
                // Get some code from a GitHub repository
                git 'https://github.com/jglick/simple-maven-project-with-tests.git'

                // Run Maven on a Unix agent.               
                withMaven {
                    sh "mvn -Dmaven.test.failure.ignore=true clean package"
                }
            }
        }
    }
}
```

Explicit archiveArtifacts test:
```
pipeline {
    agent any

    stages {
        stage('Hello') {
            steps {
                sh 'date > foo.txt'
            }
        }
    }

    post {
        always {
            archiveArtifacts artifacts: 'foo.txt'
        }
    }
}
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
